### PR TITLE
Copied SAI profile handler from SONiC project

### DIFF
--- a/inc/opx/nas_ndi_event_logs.h
+++ b/inc/opx/nas_ndi_event_logs.h
@@ -63,6 +63,9 @@
 #define NDI_LOG_INFO(ID, msg, ...) \
                    EV_LOGGING(NDI, INFO, ID, msg, ##__VA_ARGS__)
 
+#define NDI_INIT_LOG_INFO(msg, ...) \
+                   NDI_LOG_INFO("NDI-INIT", msg, ##__VA_ARGS__)
+
 #define NDI_LAG_LOG_INFO(msg, ...) \
                    NDI_LOG_INFO("NDI-LAG", msg, ##__VA_ARGS__)
 

--- a/inc/opx/nas_ndi_int.h
+++ b/inc/opx/nas_ndi_int.h
@@ -44,7 +44,7 @@
 extern "C"{
 #endif
 
-
+#define DEFAULT_SAI_PROFILE_FILE "/etc/opx/sai-profile.ini"
 
 /**
  * @class SAI API Table

--- a/inc/opx/nas_ndi_utils.h
+++ b/inc/opx/nas_ndi_utils.h
@@ -88,6 +88,13 @@ static inline t_std_error ndi_utl_mk_std_err (enum e_std_error_subsystems sub,
              STD_ERR_MK (sub, e_std_err_code_FAIL, 0);
 }
 
+t_std_error handle_profile_map(sai_switch_profile_id_t profile_id,
+                               const char *profile_file_name);
+
+int ndi_profile_get_next_value(sai_switch_profile_id_t profile_id, const char **variable, const char **value);
+
+const char *ndi_profile_get_value(sai_switch_profile_id_t profile_id, const char *variable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nas_ndi_init.c
+++ b/src/nas_ndi_init.c
@@ -42,7 +42,6 @@
 #include<unistd.h>
 #include <inttypes.h>
 
-
 typedef enum {
     ndi_internal_event_T_SWITCH_OPER,
     ndi_internal_event_T_FDB,
@@ -80,28 +79,8 @@ typedef struct {
 static std_thread_create_param_t _thread;
 static int _nas_fd[2];        //used with the pipe function call ([0] = read side, [1] = write)
 
-static const char* ndi_profile_get_value(sai_switch_profile_id_t profile_id,
-                                     const char* variable)
-{
-    /*  @todo TODO  implement this later */
-    NDI_INIT_LOG_TRACE("get value for the key %s\n", variable);
-    return NULL;
-}
-
-static int ndi_profile_get_next_value(sai_switch_profile_id_t profile_id,
-                                   const char** variable,
-                                   const char** value)
-{
-    /*  @todo TODO implement this later */
-    NDI_INIT_LOG_TRACE("get next key-value pair\n");
-    *variable = NULL;
-    *value = NULL;
-    return -1; /*  return -1 for end of the list */
-}
-
 static t_std_error nas_ndi_service_method_init(service_method_table_t **service_ptr)
 {
-
     if (service_ptr == NULL) {
         return (STD_ERR(NPU, PARAM, 0));
     }
@@ -581,6 +560,7 @@ t_std_error ndi_initialize_switch(nas_ndi_db_t *ndi_db_ptr)
                                          ndi_packet_rx_cb;
     }
     /*  initialize the NPU */
+    handle_profile_map(ndi_db_ptr->npu_profile_id, getenv("OPX_SAI_PROFILE_FILE"));
 
     sai_ret = sai_switch_api_tbl->initialize_switch(ndi_db_ptr->npu_profile_id, NULL,
                                                     NULL, &switch_notification);

--- a/src/nas_ndi_utils.cpp
+++ b/src/nas_ndi_utils.cpp
@@ -36,12 +36,21 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <set>
+#include <sstream>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
 #define NDI_SAI_PORT_OBJECT_TYPE_BITPOS     48
 #define NDI_SAI_PORT_OBJECT_ID_BITPOS     0
 
 #define NDI_SAI_PORT_OBJECT_ID_BITMASK       0x0000ffffffffffff
 #define NDI_SAI_PORT_OBJECT_TYPE_BITMASK     0x0fff000000000000
 
+static std::map<sai_switch_profile_id_t, size_t> profile_id_map;
+static std::vector<std::map<std::string, std::string>> profile_map;
+static std::vector<std::map<std::string, std::string>::iterator> profile_iter;
 
 static std::map<ndi_stat_id_t ,sai_port_stat_t>
 ndi_to_sai_if_stat_ids = {
@@ -226,4 +235,91 @@ bool ndi_to_sai_vlan_stats(ndi_stat_id_t ndi_id, sai_vlan_stat_t * sai_id){
     }
     *sai_id = it->second;
     return true;
+}
+
+const char *ndi_profile_get_value(sai_switch_profile_id_t profile_id, const char *variable) {
+    NDI_INIT_LOG_TRACE("get value for the key %s\n", variable);
+    if (variable == NULL) {
+        NDI_INIT_LOG_INFO("variable for the key %s is null", variable);
+        return NULL;
+    }
+    size_t profile_index = profile_id_map[profile_id];
+    auto it = profile_map[profile_index].find(variable);
+    if (it == profile_map[profile_index].end()) {
+        NDI_INIT_LOG_INFO("%s: NULL", variable);
+        return NULL;
+    }
+    NDI_INIT_LOG_TRACE("%s: %s", variable, it->second.c_str());
+    return it->second.c_str();
+}
+
+int ndi_profile_get_next_value(sai_switch_profile_id_t profile_id, const char **variable, const char **value)
+{
+    /*  @todo TODO implement this later */
+    NDI_INIT_LOG_TRACE("get next key-value pair\n");
+    size_t profile_index = profile_id_map[profile_id];
+    if (value == NULL) {
+        NDI_INIT_LOG_TRACE("resetting profile map iterator");
+        profile_iter[profile_index] = profile_map[profile_index].begin();
+        return 0;
+    }
+    if (variable == NULL) {
+        NDI_INIT_LOG_INFO("variable is null");
+        return -1;
+    }
+    if (profile_iter[profile_index] == profile_map[profile_index].end()) {
+        NDI_INIT_LOG_INFO("iterator reached end");
+        return -1;
+    }
+    *variable = profile_iter[profile_index]->first.c_str();
+    *value = profile_iter[profile_index]->second.c_str();
+    NDI_INIT_LOG_TRACE("key: %s:%s", *variable, *value);
+    profile_iter[profile_index]++;
+    return 0;
+}
+
+t_std_error handle_profile_map(sai_switch_profile_id_t profile_id, 
+                               const char *profile_file_name) {
+    NDI_INIT_LOG_TRACE("handle profile map");
+    std::string profile_map_file = DEFAULT_SAI_PROFILE_FILE;
+    if (profile_file_name != NULL) {
+        profile_map_file = profile_file_name;
+    }
+
+    size_t profile_index = profile_id_map.size();
+    profile_id_map[profile_id] = profile_index;
+
+    if (profile_map.size() <= profile_id) {
+        profile_map.resize(profile_index + 1);
+    }
+    if (profile_iter.size() <= profile_index) {
+        size_t profile_iter_size = profile_iter.size();
+        profile_iter.resize(profile_index + 1);
+        for (int i = profile_iter_size; i <= profile_iter.size(); ++i) {
+            profile_iter[i] = profile_map[i].begin();
+        }
+    }
+    std::ifstream profile(profile_map_file);
+    if (!profile.is_open()) {
+        NDI_INIT_LOG_INFO("failed to open profile map file: %s : %s using SAI default profile",
+                          profile_map_file.c_str(), strerror(errno));
+        return STD_ERR_OK;
+    }
+    std::string line;
+    while(getline(profile, line)) {
+        if (line.size() > 0 && (line[0] == '#' || line[0] == ';'))
+            continue;
+
+        size_t pos = line.find("=");
+        if (pos == std::string::npos) {
+            NDI_INIT_LOG_INFO("not found '=' in line %s", line.c_str());
+            continue;
+        }
+        std::string key = line.substr(0, pos);
+        std::string value = line.substr(pos + 1);
+        profile_map[profile_id][key] = value;
+
+        NDI_INIT_LOG_INFO("insert: %s:%s", key.c_str(), value.c_str());
+    }
+    return STD_ERR_OK;
 }


### PR DESCRIPTION
Copied SONiC implementation of `handle_profile_map`, `ndi_profile_get_next_value`, `ndi_profile_get_value`.
The default SAI profile file name is `/etc/opx/sai-profile`.
The format of sai-profile file is the same as used in SONiC and PTF test framework.
Since this api is intended to be used from systemd service, environment variable is the only viable way to change profile filename in runtime.
