### PR TITLE
Added stub for hif trap type attribute

### DIFF
--- a/src/nas_ndi_packet.c
+++ b/src/nas_ndi_packet.c
@@ -107,6 +107,9 @@ static t_std_error ndi_packet_get_attr (const sai_attribute_t *p_attr, ndi_packe
         case SAI_HOSTIF_PACKET_ATTR_INGRESS_LAG:
             // @Todo - to handle lag case
             break;
+        case SAI_HOSTIF_PACKET_ATTR_TRAP_TYPE:
+            // @Todo - to handle trap type attr
+            break;
 
         case SAI_HOSTIF_PACKET_ATTR_USER_TRAP_ID:
             if(p_attr->value.s32 == SAI_HOSTIF_TRAP_TYPE_SAMPLEPACKET)


### PR DESCRIPTION
    As per SAI requirments, trapped packets are provided with SAI_HOSTIF_PACKET_ATTR_TRAP_TYPE
    attribute, specifying trap type. The application can process different trap types in different ways.
    NAS doesn't provide different treatment for different trap types as of now.
    The stub prevents dropping of packets with set SAI_HOSTIF_PACKET_ATTR_TRAP_TYPE attribute.